### PR TITLE
Added fallback to parser code incase it fails to read a dotoo file.

### DIFF
--- a/autoload/dotoo/parser.vim
+++ b/autoload/dotoo/parser.vim
@@ -86,6 +86,9 @@ function! dotoo#parser#parsefile(options) abort
     let lines = getline(1,'$')
   elseif filereadable(opts.file) && fnamemodify(opts.file, ':e') ==# 'dotoo'
     let lines = s:readfile(opts.file)
+    if len(lines) ==# 0
+      let lines = readfile(opts.file)
+    endif
   else
     return
   endif

--- a/autoload/dotoo/parser.vim
+++ b/autoload/dotoo/parser.vim
@@ -7,7 +7,6 @@ function! s:readfile(file)
   if !bufloaded(a:file)
     let old_view = winsaveview()
     silent exe 'noauto split' a:file
-    quit
     call winrestview(old_view)
   endif
   return getbufline(a:file, 1, '$')
@@ -86,9 +85,6 @@ function! dotoo#parser#parsefile(options) abort
     let lines = getline(1,'$')
   elseif filereadable(opts.file) && fnamemodify(opts.file, ':e') ==# 'dotoo'
     let lines = s:readfile(opts.file)
-    if len(lines) ==# 0
-      let lines = readfile(opts.file)
-    endif
   else
     return
   endif


### PR DESCRIPTION
Hello, I love your plugin, unfortunately I had an issue which I think I fixed but since I am not a vimscript expert I was hoping you could give me some feedback.

I installed the plugin and added this to my vimrc

```vim
:let g:dotoo#agenda#files = ['/home/me/.vim/bundle/vim-dotoo/dotoo.dotoo']
```

If I open `/home/me/.vim/bundle/vim-dotoo/dotoo.dotoo` with vim then look at the agenda, todos etc. everything is fine however if the dotoo file is not open in Vim then the agenda, todos etc are empty.

I tracked the problem to the following code inside `autoload/dotoo/parser.vim`

```vim
function! dotoo#parser#parsefile(options) abort
  ...
  if expand('%:p') ==# fnamemodify(opts.file, ':p') && &filetype ==# 'dotoo'
    let lines = getline(1,'$')
  elseif filereadable(opts.file) && fnamemodify(opts.file, ':e') ==# 'dotoo'
    let lines = s:readfile(opts.file)
  else
    return
  endif
   ...
endfunction
```

When the file is opened with Vim then the first branch is taken and everything works. When the file is not open then the second branch is taken. The problem was that `s:readfile` would return an empty list.

As I do not understand why this code failed for me my solution was to check if the list is empty and try and alternative syntax which does work for me. 

I would appreciate any ideas on what the problem might be and whether my solution is acceptable.

Thank you.