### PR TITLE
Don't show done items in todo list

### DIFF
--- a/autoload/dotoo/agenda_views/todos.vim
+++ b/autoload/dotoo/agenda_views/todos.vim
@@ -23,11 +23,13 @@ function! s:build_todos(dotoos, ...)
     let headlines = s:todos_deadlines[file]
     call dotoo#agenda#headlines(headlines, 1)
     for headline in headlines
-      let todo = printf('%s %10s: %-70s %s', '',
-            \ headline.key,
-            \ headline.todo_title(),
-            \ headline.tags)
-      call add(todos, todo)
+      if !headline.done()
+        let todo = printf('%s %10s: %-70s %s', '',
+              \ headline.key,
+              \ headline.todo_title(),
+              \ headline.tags)
+        call add(todos, todo)
+      endif
     endfor
   endfor
   if empty(todos)


### PR DESCRIPTION
Currently, in the todo view of the agenda, all items are shown, including those marked as done. I changed this to show only items which are still active.