### PR TITLE
Use first line as foldtext

### DIFF
--- a/ftplugin/dotoo.vim
+++ b/ftplugin/dotoo.vim
@@ -5,6 +5,7 @@ let b:did_ftplugin = 1
 
 setl foldexpr=DotooFoldExpr()
 setl foldmethod=expr
+setl foldtext=getline(v:foldstart)
 
 let s:syntax = dotoo#parser#lexer#syntax()
 function! DotooFoldExpr()


### PR DESCRIPTION
Currently, no specific foldtext is set. This sets the foldtext to the headline. Alternatively, 3 dots could be added as with vim-orgmode.