### PR TITLE
Add automatic indentation

### DIFF
--- a/indent/dotoo.vim
+++ b/indent/dotoo.vim
@@ -1,4 +1,5 @@
-" Based on indent of https://github.com/plasticboy/vim-markdown
+" Based on of https://github.com/plasticboy/vim-markdown indent script
+
 if exists("b:did_indent") | finish | endif
 let b:did_indent = 1
 
@@ -7,28 +8,20 @@ setlocal nolisp
 setlocal autoindent
 
 " Only define the function once
-" TODO: isn't this build in?
 if exists("*GetDotooIndent") | finish | endif
 
-" TODO: function for *s
 function! s:is_list_start(line)
-    return a:line =~ '^\s*[-+*] \+' && a:line !~ '^\*'
+    return a:line =~ '^\s*[-+] \+'
 endfunction
 function! s:is_checkbox_start(line)
     return a:line =~ '^\s*- \[[ -X]\] \+'
 endfunction
-
-function! s:is_blank_line(line)
-    return a:line =~ '^$'
+function! s:is_headline(line)
+    return a:line =~ '^*\+ \+'
 endfunction
 
-" TODO _ between words for consistency?
-function! s:prevnonblank(lnum)
-    let i = a:lnum
-    while i > 1 && s:is_blank_line(getline(i))
-        let i -= 1
-    endwhile
-    return i
+function! s:item_depth(line)
+    return strlen(substitute(a:line, '^\(\*\+\) .*$', '\1', ''))
 endfunction
 
 function GetDotooIndent()
@@ -36,18 +29,19 @@ function GetDotooIndent()
     let lnum = prevnonblank(v:lnum - 1)
     " At the start of the file use zero indent.
     if lnum == 0 | return 0 | endif
-
     let ind = indent(lnum)
     let line = getline(lnum)    " Last line
     let cline = getline(v:lnum) " Current line
-    " Current line is the first line of an item, do not change indent
-    if s:is_list_start(cline) 
+    " Current line is the first line of a list item or headline, do not change indent
+    if s:is_list_start(cline) || s:is_headline(cline)
         return indent(v:lnum)
-    " Last line is the first line of an item, increase indent
+    " Last line is the first line of a list item or headline, increase indent
     elseif s:is_checkbox_start(line)
         return ind + 6
     elseif s:is_list_start(line)
         return ind + 2
+    elseif s:is_headline(line)
+        return s:item_depth(line) + 1
     else
         return ind
     endif

--- a/indent/dotoo.vim
+++ b/indent/dotoo.vim
@@ -11,38 +11,38 @@ setlocal autoindent
 if exists("*GetDotooIndent") | finish | endif
 
 function! s:is_list_start(line)
-    return a:line =~ '^\s*[-+] \+'
+  return a:line =~ '^\s*[-+] \+'
 endfunction
 function! s:is_checkbox_start(line)
-    return a:line =~ '^\s*- \[[ -X]\] \+'
+  return a:line =~ '^\s*- \[[ -X]\] \+'
 endfunction
 function! s:is_headline(line)
-    return a:line =~ '^*\+ \+'
+  return a:line =~ '^*\+ \+'
 endfunction
 
 function! s:item_depth(line)
-    return strlen(substitute(a:line, '^\(\*\+\) .*$', '\1', ''))
+  return strlen(substitute(a:line, '^\(\*\+\) .*$', '\1', ''))
 endfunction
 
 function GetDotooIndent()
-    " Find a non-blank line above the current line.
-    let lnum = prevnonblank(v:lnum - 1)
-    " At the start of the file use zero indent.
-    if lnum == 0 | return 0 | endif
-    let ind = indent(lnum)
-    let line = getline(lnum)    " Last line
-    let cline = getline(v:lnum) " Current line
-    " Current line is the first line of a list item or headline, do not change indent
-    if s:is_list_start(cline) || s:is_headline(cline)
-        return indent(v:lnum)
-    " Last line is the first line of a list item or headline, increase indent
-    elseif s:is_checkbox_start(line)
-        return ind + 6
-    elseif s:is_list_start(line)
-        return ind + 2
-    elseif s:is_headline(line)
-        return s:item_depth(line) + 1
-    else
-        return ind
-    endif
+  " Find a non-blank line above the current line.
+  let lnum = prevnonblank(v:lnum - 1)
+  " At the start of the file use zero indent.
+  if lnum == 0 | return 0 | endif
+  let ind = indent(lnum)
+  let line = getline(lnum)    " Last line
+  let cline = getline(v:lnum) " Current line
+  " Current line is the first line of a list item or headline, do not change indent
+  if s:is_list_start(cline) || s:is_headline(cline)
+    return indent(v:lnum)
+  " Last line is the first line of a list item or headline, increase indent
+  elseif s:is_checkbox_start(line)
+    return ind + 6
+  elseif s:is_list_start(line)
+    return ind + 2
+  elseif s:is_headline(line)
+    return s:item_depth(line) + 1
+  else
+    return ind
+  endif
 endfunction

--- a/indent/dotoo.vim
+++ b/indent/dotoo.vim
@@ -10,15 +10,19 @@ setlocal autoindent
 " TODO: isn't this build in?
 if exists("*GetDotooIndent") | finish | endif
 
-function! s:is_li_start(line)
-    return a:line !~ '^ *\([*-]\)\%( *\1\)\{2}\%( \|\1\)*$' &&
-      \    a:line =~ '^\s*[*+-] \+'
+" TODO: function for *s
+function! s:is_list_start(line)
+    return a:line =~ '^\s*[-+*] \+' && a:line !~ '^\*'
+endfunction
+function! s:is_checkbox_start(line)
+    return a:line =~ '^\s*- \[[ -X]\] \+'
 endfunction
 
 function! s:is_blank_line(line)
     return a:line =~ '^$'
 endfunction
 
+" TODO _ between words for consistency?
 function! s:prevnonblank(lnum)
     let i = a:lnum
     while i > 1 && s:is_blank_line(getline(i))
@@ -28,20 +32,22 @@ function! s:prevnonblank(lnum)
 endfunction
 
 function GetDotooIndent()
-    let list_ind = 2
     " Find a non-blank line above the current line.
     let lnum = prevnonblank(v:lnum - 1)
     " At the start of the file use zero indent.
     if lnum == 0 | return 0 | endif
+
     let ind = indent(lnum)
     let line = getline(lnum)    " Last line
     let cline = getline(v:lnum) " Current line
-    if s:is_li_start(cline) 
-        " Current line is the first line of a list item, do not change indent
+    " Current line is the first line of an item, do not change indent
+    if s:is_list_start(cline) 
         return indent(v:lnum)
-    elseif s:is_li_start(line)
-        " Last line is the first line of a list item, increase indent
-        return ind + list_ind
+    " Last line is the first line of an item, increase indent
+    elseif s:is_checkbox_start(line)
+        return ind + 6
+    elseif s:is_list_start(line)
+        return ind + 2
     else
         return ind
     endif

--- a/indent/dotoo.vim
+++ b/indent/dotoo.vim
@@ -1,0 +1,48 @@
+" Based on indent of https://github.com/plasticboy/vim-markdown
+if exists("b:did_indent") | finish | endif
+let b:did_indent = 1
+
+setlocal indentexpr=GetDotooIndent()
+setlocal nolisp
+setlocal autoindent
+
+" Only define the function once
+" TODO: isn't this build in?
+if exists("*GetDotooIndent") | finish | endif
+
+function! s:is_li_start(line)
+    return a:line !~ '^ *\([*-]\)\%( *\1\)\{2}\%( \|\1\)*$' &&
+      \    a:line =~ '^\s*[*+-] \+'
+endfunction
+
+function! s:is_blank_line(line)
+    return a:line =~ '^$'
+endfunction
+
+function! s:prevnonblank(lnum)
+    let i = a:lnum
+    while i > 1 && s:is_blank_line(getline(i))
+        let i -= 1
+    endwhile
+    return i
+endfunction
+
+function GetDotooIndent()
+    let list_ind = 2
+    " Find a non-blank line above the current line.
+    let lnum = prevnonblank(v:lnum - 1)
+    " At the start of the file use zero indent.
+    if lnum == 0 | return 0 | endif
+    let ind = indent(lnum)
+    let line = getline(lnum)    " Last line
+    let cline = getline(v:lnum) " Current line
+    if s:is_li_start(cline) 
+        " Current line is the first line of a list item, do not change indent
+        return indent(v:lnum)
+    elseif s:is_li_start(line)
+        " Last line is the first line of a list item, increase indent
+        return ind + list_ind
+    else
+        return ind
+    endif
+endfunction


### PR DESCRIPTION
This adds automatic indentation to vim-dotoo, as this is currently absent. I based myself on the indentation of [vim-markdown](https://github.com/plasticboy/vim-markdown), which is quite close to what's needed, and I hadn't any experience in indentation plugins.