### PR TITLE
Disable spell checking on keywords

### DIFF
--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -169,7 +169,7 @@ if !exists('g:loaded_dotoo_syntax')
           break
         endif
       endfor
-      exec 'syntax match dotoo_todo_keyword_' . l:_i . ' /\*\{1,\}\s\{1,\}\zs' . l:_i .'\(\s\|$\)/ ' . a:todo_headings
+      exec 'syntax match dotoo_todo_keyword_' . l:_i . ' /\*\{1,\}\s\{1,\}\zs' . l:_i .'\(\s\|$\)/ ' . a:todo_headings . ' contains=@NoSpell'
       exec 'hi def link dotoo_todo_keyword_' . l:_i . ' ' . l:group
     endfor
   endfunction

--- a/syntax/dotooagenda.vim
+++ b/syntax/dotooagenda.vim
@@ -146,7 +146,7 @@ if !exists('g:loaded_dotooagenda_syntax')
           break
         endif
       endfor
-      exec 'syntax match dotootodo_todo_keyword_' . l:_i . ' /' . l:_i .'/ ' . a:todo_headings
+      exec 'syntax match dotootodo_todo_keyword_' . l:_i . ' /' . l:_i .'/ ' . a:todo_headings . ' contains=@NoSpell'
       exec 'hi def link dotootodo_todo_keyword_' . l:_i . ' ' . l:group
     endfor
   endfunction


### PR DESCRIPTION
I don't think the keywords should be spell-checked, their prime function is that of a syntax element, not natural language.