### PR TITLE
Support org extension

### DIFF
--- a/autoload/dotoo/agenda.vim
+++ b/autoload/dotoo/agenda.vim
@@ -61,7 +61,7 @@ function! s:add_agenda_file(...)
 endfunction
 
 function! s:add_agenda_file_menu()
-  if expand('%:e') ==# 'dotoo' && !s:has_agenda_file()
+  if &filetype ==# 'dotoo' && !s:has_agenda_file()
     if dotoo#utils#getchar('Do you wish to add the current file in agenda files? (y/n): ', '[yn]') == 'y'
       call s:add_agenda_file()
       return 1
@@ -185,7 +185,7 @@ function! dotoo#agenda#get_headline_by_title(file_title)
   if a:file_title =~# ':'
     let [filekey, title] = split(a:file_title, ':')
     let bufname = bufname(filekey)
-    let bufname = empty(bufname) ? bufname(filekey . '.dotoo') : bufname
+    let bufname = empty(bufname) ? bufname(filekey . '.{dotoo,org}') : bufname
     let dotoo = get(s:agenda_dotoos, bufname, '')
     if !empty(dotoo)
       let headlines = dotoo.filter("v:val.title =~# '" . title . "'")

--- a/autoload/dotoo/agenda_views/todos.vim
+++ b/autoload/dotoo/agenda_views/todos.vim
@@ -11,7 +11,7 @@ function! s:build_todos(dotoos, ...)
     let s:todos_deadlines = {}
     call dotoo#agenda#headlines([])
     for dotoo in values(a:dotoos)
-      let headlines = dotoo.filter('empty(v:val.metadate()) && !empty(v:val.todo)')
+      let headlines = dotoo.filter('empty(v:val.metadate()) && !empty(v:val.todo) && !v:val.done()')
       call dotoo#agenda#apply_filters(headlines)
       let s:todos_deadlines[dotoo.file] = headlines
     endfor
@@ -23,13 +23,11 @@ function! s:build_todos(dotoos, ...)
     let headlines = s:todos_deadlines[file]
     call dotoo#agenda#headlines(headlines, 1)
     for headline in headlines
-      if !headline.done()
-        let todo = printf('%s %10s: %-70s %s', '',
-              \ headline.key,
-              \ headline.todo_title(),
-              \ headline.tags)
-        call add(todos, todo)
-      endif
+      let todo = printf('%s %10s: %-70s %s', '',
+            \ headline.key,
+            \ headline.todo_title(),
+            \ headline.tags)
+      call add(todos, todo)
     endfor
   endfor
   if empty(todos)

--- a/autoload/dotoo/parser.vim
+++ b/autoload/dotoo/parser.vim
@@ -84,7 +84,7 @@ function! dotoo#parser#parsefile(options) abort
   let lines = []
   if expand('%:p') ==# fnamemodify(opts.file, ':p') && &filetype ==# 'dotoo'
     let lines = getline(1,'$')
-  elseif filereadable(opts.file) && fnamemodify(opts.file, ':e') ==# 'dotoo'
+  elseif filereadable(opts.file) && fnamemodify(opts.file, ':e') =~# '\v^(dotoo|org)$'
     let lines = s:readfile(opts.file)
   else
     return

--- a/plugin/dotoo.vim
+++ b/plugin/dotoo.vim
@@ -47,7 +47,7 @@ nnoremap <silent> gC :<C-U>call dotoo#capture#capture()<CR>
 augroup dotoo
   au!
 
-  autocmd BufNewFile,BufRead *.dotoo call dotoo#parser#parsefile({'force': 1})
+  autocmd FileType dotoo call dotoo#parser#parsefile({'force': 1})
 augroup END
 
 " Register Agenda Views


### PR DESCRIPTION
Currently, only the dotoo extension is supported. But, dotoo is an non-standard extensions for the orgmode file format. Tools which do support orgmode, won't recognize dotoo files as such. For this reason, I think vim-dotoo should at least work when using files with the org extension.

A second change is a fix to the todo view, as my change in pull request #17 did introduce a bug, which is now fixed.