### PR TITLE
Blank lines

### DIFF
--- a/autoload/dotoo/parser/headline.vim
+++ b/autoload/dotoo/parser/headline.vim
@@ -215,7 +215,9 @@ function! dotoo#parser#headline#new(...) abort
         \ 'headlines': []
         \ }
 
+  let last_token_lnum = token.lnum
   if has_key(token, 'type')
+    let last_token_lnum = get(tokens, -1, token).lnum
     let blanks = []
     while len(tokens)
       let token = remove(tokens, 0)
@@ -245,7 +247,7 @@ function! dotoo#parser#headline#new(...) abort
 
   call extend(headline, s:headline_methods)
   if empty(tokens)
-    let headline.last_lnum = line('$')
+    let headline.last_lnum = last_token_lnum
   else
     let headline.last_lnum = get(tokens, 0).lnum - 1
   endif

--- a/autoload/dotoo/parser/headline.vim
+++ b/autoload/dotoo/parser/headline.vim
@@ -219,9 +219,11 @@ function! dotoo#parser#headline#new(...) abort
     let blanks = []
     while len(tokens)
       let token = remove(tokens, 0)
-      if token.type ==# s:syntax.line.type
+      if token.type != s:syntac.blank.type
         call extend(headline.content, blanks)
         let blanks = []
+      endif
+      if token.type ==# s:syntax.line.type
         call add(headline.content, token.content[0])
       elseif token.type == s:syntax.metadata.type
         call extend(headline.metadata, dotoo#parser#metadata#new(token))

--- a/autoload/dotoo/parser/headline.vim
+++ b/autoload/dotoo/parser/headline.vim
@@ -94,7 +94,7 @@ function! s:headline_methods.serialize() dict
   call add(lines, self.line())
   call extend(lines, self.content)
   let metadata = self.metadata.serialize()
-  if metadata != ''
+  if !empty(metadata)
     call add(lines, self.metadata.serialize())
   endif
   call extend(lines, self.properties.serialize())

--- a/autoload/dotoo/parser/headline.vim
+++ b/autoload/dotoo/parser/headline.vim
@@ -219,11 +219,9 @@ function! dotoo#parser#headline#new(...) abort
     let blanks = []
     while len(tokens)
       let token = remove(tokens, 0)
-      if token.type != s:syntax.blank.type
+      if token.type ==# s:syntax.line.type
         call extend(headline.content, blanks)
         let blanks = []
-      endif
-      if token.type ==# s:syntax.line.type
         call add(headline.content, token.content[0])
       elseif token.type == s:syntax.metadata.type
         call extend(headline.metadata, dotoo#parser#metadata#new(token))
@@ -246,7 +244,11 @@ function! dotoo#parser#headline#new(...) abort
   endif
 
   call extend(headline, s:headline_methods)
-  let headline.last_lnum = headline.lnum + len(headline.serialize()) - 1
+  if empty(tokens)
+    let headline.last_lnum = line('$')
+  else
+    let headline.last_lnum = get(tokens, 0).lnum - 1
+  endif
   let headline.id = sha256(string(headline))
 
   " Has side-effects

--- a/autoload/dotoo/parser/headline.vim
+++ b/autoload/dotoo/parser/headline.vim
@@ -219,7 +219,7 @@ function! dotoo#parser#headline#new(...) abort
     let blanks = []
     while len(tokens)
       let token = remove(tokens, 0)
-      if token.type != s:syntac.blank.type
+      if token.type != s:syntax.blank.type
         call extend(headline.content, blanks)
         let blanks = []
       endif


### PR DESCRIPTION
Currently, blank lines aren't really supported, while they are used to indicate paragraphs. Worse, if empty lines do occur, serialisation doesn't work properly, as empty lines are left out, and the last lines of the original headline aren't deleted.
