### PR TITLE
Indentation in dotoocapture

### DIFF
--- a/indent/dotoocapture.vim
+++ b/indent/dotoocapture.vim
@@ -1,0 +1,2 @@
+if exists("b:did_indent") | finish | endif
+runtime! indent/dotoo.vim


### PR DESCRIPTION
When using capture, there is no indentation as this is only for the dotoo filetype, this fixes this.