### PR TITLE
Don't highlight space of TODO

### DIFF
--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -169,7 +169,7 @@ if !exists('g:loaded_dotoo_syntax')
           break
         endif
       endfor
-      exec 'syntax match dotoo_todo_keyword_' . l:_i . ' /\*\{1,\}\s\{1,\}\zs' . l:_i .'\(\s\|$\)/ ' . a:todo_headings . ' contains=@NoSpell'
+      exec 'syntax match dotoo_todo_keyword_' . l:_i . ' /\*\{1,\}\s\{1,\}\zs' . l:_i .'\(\s\|$\)/he=e-1 ' . a:todo_headings . ' contains=@NoSpell'
       exec 'hi def link dotoo_todo_keyword_' . l:_i . ' ' . l:group
     endfor
   endfunction


### PR DESCRIPTION
The space after the TODO keywords in dotoo is highlighted as well, this fixes this.