### PR TITLE
Remove use of reltime to get current time

### DIFF
--- a/autoload/dotoo/time.vim
+++ b/autoload/dotoo/time.vim
@@ -48,11 +48,8 @@ function! s:datetime_methods.to_seconds() dict
 endfunction
 
 function! s:localtime(...)
-  let ts  = a:0 ? a:1 : has('unix') ? reltimestr(reltime()) : localtime() . '.0'
+  let ts  = a:0 ? a:1 : localtime()
   let rp = a:0 > 1 ? a:2 : ''
-  let us  = matchstr(ts, '\.\zs.\{0,6\}')
-  let us .= repeat(0, 6 - strlen(us))
-  let us  = matchstr(us, '[1-9].*')
   " sepoch    = seconds since epoch (Jan 1, 1970)
   " depoch    = days since epoch
   " stzoffset = timezone offset from UTC in seconds
@@ -67,8 +64,7 @@ function! s:localtime(...)
         \, 'minute' : +strftime('%M', ts)
         \, 'second' : +strftime('%S', ts)
         \, 'sepoch' : +strftime('%s', ts)
-        \, 'repeat' : rp
-        \, 'smicro' : us / 1000}
+        \, 'repeat' : rp}
   let datetime.depoch = s:jd(datetime.year, datetime.month, datetime.day)
         \ - s:epoch_jd
   let real_ts = s:days_to_seconds(datetime.depoch)


### PR DESCRIPTION
As, mention earlier, using localtime seems to fix the issues with neovim (#13). Doing so, all code involving microseconds can be deleted.