### PR TITLE
Syntax merge from vim-orgmode

### DIFF
--- a/autoload/dotoo/checkbox.vim
+++ b/autoload/dotoo/checkbox.vim
@@ -1,17 +1,17 @@
 function! dotoo#checkbox#is_checkbox(line)
-  return a:line =~ '^\s*[-+*] \[[ -X]\] ' && !dotoo#checkbox#is_headline(a:line)
+  return a:line =~ '^\s*[-+*] \[[ -X]\]\(\s\|$\)' && !dotoo#checkbox#is_headline(a:line)
 endfunction
 function! dotoo#checkbox#is_unchecked_checkbox(line)
-  return a:line =~ '^\s*[-+*] \[ \] ' && !dotoo#checkbox#is_headline(a:line)
+  return a:line =~ '^\s*[-+*] \[ \]\(\s\|$\)' && !dotoo#checkbox#is_headline(a:line)
 endfunction
 function! dotoo#checkbox#is_partial_checkbox(line)
-  return a:line =~ '^\s*[-+*] \[-\] ' && !dotoo#checkbox#is_headline(a:line)
+  return a:line =~ '^\s*[-+*] \[-\]\(\s\|$\)' && !dotoo#checkbox#is_headline(a:line)
 endfunction
 function! dotoo#checkbox#is_checked_checkbox(line)
-  return a:line =~ '^\s*[-+*] \[X\] ' && !dotoo#checkbox#is_headline(a:line)
+  return a:line =~ '^\s*[-+*] \[X\]\(\s\|$\)' && !dotoo#checkbox#is_headline(a:line)
 endfunction
 function dotoo#checkbox#is_list_item(line)
-  return a:line =~ '^\s*[-+*] ' && !dotoo#checkbox#is_headline(a:line)
+  return a:line =~ '^\s*[-+*]\(\s\|$\)' && !dotoo#checkbox#is_headline(a:line)
 endfunction
 function! dotoo#checkbox#is_headline(line)
   return a:line =~ '^\*\+ '
@@ -74,16 +74,16 @@ function! s:process_parents(nline)
     let nlast = nline
     let lind = indent(nlast)
     if dotoo#checkbox#is_unchecked_checkbox(line)
-      call setline(nline, substitute(line, '\([-+*]\) \[ \] ', '\1 [-] ', ''))
+      call setline(nline, substitute(line, '\([-+*]\) \[ \]\(\s\|$\)', '\1 [-]\2', ''))
     endif
     if dotoo#checkbox#is_checked_checkbox(line)
-      call setline(nline, substitute(line, '\([-+*]\) \[X\] ', '\1 [-] ', ''))
+      call setline(nline, substitute(line, '\([-+*]\) \[X\]\(\s\|$\)', '\1 [-]\2', ''))
     endif
     let counts = s:count_children(nlast)
     if counts[0] + counts[1] == 0
-      call setline(nlast, substitute(getline(nlast), '\([-+*]\) \[-\] ', '\1 [X] ', ''))
+      call setline(nlast, substitute(getline(nlast), '\([-+*]\) \[-\]\(\s\|$\)', '\1 [X]\2', ''))
     elseif counts[1] + counts[2] == 0
-      call setline(nlast, substitute(getline(nlast), '\([-+*]\) \[-\] ', '\1 [ ] ', ''))
+      call setline(nlast, substitute(getline(nlast), '\([-+*]\) \[-\]\(\s\|$\)', '\1 [ ]\2', ''))
     endif
     call s:update_progress(nlast, counts)
   endwhile
@@ -98,10 +98,10 @@ function! dotoo#checkbox#toggle()
   let line = getline(nline)
 
   if dotoo#checkbox#is_unchecked_checkbox(line)
-    call setline(nline, substitute(line, '\([-+*]\) \[ \] ', '\1 [X] ', ''))
+    call setline(nline, substitute(line, '\([-+*]\) \[ \]\(\s\|$\)', '\1 [X]\2', ''))
     call s:process_parents(nline)
   elseif dotoo#checkbox#is_checked_checkbox(line)
-    call setline(nline, substitute(line, '\([-+*]\) \[X\] ', '\1 [ ] ', ''))
+    call setline(nline, substitute(line, '\([-+*]\) \[X\]\(\s\|$\)', '\1 [ ]\2', ''))
     call s:process_parents(nline)
   endif
   call setpos('.', pos)

--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -36,7 +36,7 @@ hi def dotoo_underline term=underline cterm=underline gui=underline
 " Headings: {{{
 "" Enable Syntax HL: {{{
 let s:contains = ' contains=dotoo_timestamp,dotoo_subtask_percent,dotoo_subtask_number,dotoo_subtask_percent_100,'.
-      \ 'dotoo_subtask_number_all,dotoo_list_checkbox,dotoo_list_dt,dotoo_bold,dotoo_italic,dotoo_underline,' .
+      \ 'dotoo_subtask_number_all,dotoo_list_checkbox,dotoo_bold,dotoo_italic,dotoo_underline,' .
       \ 'dotoo_code,dotoo_verbatim'
 if g:dotoo_heading_shade_leading_stars == 1
   let s:contains .= ',dotoo_shade_stars'
@@ -196,34 +196,6 @@ syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d\]--\[\d\d\d\d
 syn match dotoo_timestamp /\(\[%%(diary-float.\+\]\)/
 
 hi def link dotoo_timestamp SpecialKey
-" }}}
-" Lists: {{{
-
-" Ordered Lists:
-" 1. list item
-" 1) list item
-syn match dotoo_list_ordered "^\s*\d\+[.)]\s"
-hi def link dotoo_list_ordered Identifier
-
-" Unordered Lists:
-" - list item
-" * list item
-" + list item
-" + and - don't need a whitespace prefix
-syn match dotoo_list_unordered "^\s*[-+]\s"
-" * must have a whitespace prefix, otherwise it's a heading
-syn match dotoo_list_unordered "^\s\+\*\s"
-hi def link dotoo_list_unordered Identifier
-
-" Definition Lists:
-" - Term :: expl.
-" 1) Term :: expl.
-syntax region dotoo_list_def start="^\s*\d[.)]\s" end=" ::" keepend oneline contains=dotoo_list_unordered
-" + and - don't need a whitespace prefix
-syntax region dotoo_list_def start="^\s*[-+]\s" end=" ::" keepend oneline contains=dotoo_list_ordered
-" * must have a whitespace prefix, otherwise it's a heading
-syntax region dotoo_list_def start="^\s\+\*\s" end=" ::" keepend oneline contains=dotoo_list_ordered
-hi def link dotoo_list_def Identifier
 
 " }}}
 " Deadline And Schedule: {{{
@@ -240,21 +212,35 @@ hi def link hyperlink Underlined
 " Comments: {{{
 syntax match dotoo_comment /^#.*/
 hi def link dotoo_comment Comment
+
+" }}}
+" Lists: {{{
+
+" Ordered Lists:
+" 1. list item
+" 1) list item
+syn match dotoo_list_ordered "^\s*\(\a\|\d\+\)[.)]\s" nextgroup=dotoo_list_item 
+hi def link dotoo_list_ordered Identifier
+
+" Unordered Lists:
+" - list item
+" * list item
+" + list item
+" + and - don't need a whitespace prefix
+syn match dotoo_list_unordered "^\(\s*[-+]\|\s\+\*\)\s" nextgroup=dotoo_list_item 
+hi def link dotoo_list_unordered Identifier
+
+" Definition Lists:
+" - Term :: expl.
+" 1) Term :: expl.
+syntax match dotoo_list_def /.*\s\+::/ contained
+hi def link dotoo_list_def PreProc
+"
 " }}}
 " Bullet Lists: {{{
-" * list item (note there must be a whitespace prefix)
-syntax match dotoo_list_bullet /^\s\+\*\s/ nextgroup=dotoo_list_item
-" - list item (no whitespace required)
-" + list item (no whitespace required)
-syntax match  dotoo_list_bullet   /^\s*[+-]\s/ nextgroup=dotoo_list_item
-" 1) list item
-" 2. list item
-syntax match dotoo_list_bullet /^\s*\w\+[.)]\s/ nextgroup=dotoo_list_item
-syntax match dotoo_list_item     /.*$/ contained contains=dotoo_subtask_percent,dotoo_subtask_number,dotoo_subtask_percent_100,dotoo_subtask_number_all,dotoo_list_checkbox,dotoo_list_dt,dotoo_bold,dotoo_italic,dotoo_underline,dotoo_code,dotoo_verbatim,dotoo_timestamp
+syntax match dotoo_list_item /.*$/ contained contains=dotoo_subtask_percent,dotoo_subtask_number,dotoo_subtask_percent_100,dotoo_subtask_number_all,dotoo_list_checkbox,dotoo_bold,dotoo_italic,dotoo_underline,dotoo_code,dotoo_verbatim,dotoo_timestamp,dotoo_timestamp_inactive,dotoo_list_def 
 syntax match dotoo_list_checkbox /\[[ X-]]/ contained
-syntax match dotoo_list_dt /.*\s\+::/ contained
 hi def link dotoo_list_bullet Identifier
-hi def link dotoo_list_dt     PreProc
 hi def link dotoo_list_checkbox     PreProc
 
 " }}}

--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -41,7 +41,7 @@ let s:contains = ' contains=dotoo_timestamp,dotoo_subtask_percent,dotoo_subtask_
 if g:dotoo_heading_shade_leading_stars == 1
   let s:contains .= ',dotoo_shade_stars'
   syntax match dotoo_shade_stars /^\*\{2,\}/me=e-1 contained
-  hi def link dotoo_shade_stars NonText
+  hi def link dotoo_shade_stars Ignore
 else
   hi clear dotoo_shade_stars
 endif

--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -219,7 +219,7 @@ hi def link dotoo_comment Comment
 " Ordered Lists:
 " 1. list item
 " 1) list item
-syn match dotoo_list_ordered "^\s*\(\a\|\d\+\)[.)]\s" nextgroup=dotoo_list_item 
+syn match dotoo_list_ordered "^\s*\(\a\|\d\+\)[.)]\(\s\|$\)" nextgroup=dotoo_list_item 
 hi def link dotoo_list_ordered Identifier
 
 " Unordered Lists:
@@ -227,7 +227,7 @@ hi def link dotoo_list_ordered Identifier
 " * list item
 " + list item
 " + and - don't need a whitespace prefix
-syn match dotoo_list_unordered "^\(\s*[-+]\|\s\+\*\)\s" nextgroup=dotoo_list_item 
+syn match dotoo_list_unordered "^\(\s*[-+]\|\s\+\*\)\(\s\|$\)" nextgroup=dotoo_list_item 
 hi def link dotoo_list_unordered Identifier
 
 " Definition Lists:

--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -261,9 +261,9 @@ hi def link dotoo_title           Title
 " TODO: http://vim.wikia.com/wiki/Different_syntax_highlighting_within_regions_of_a_file
 syntax match  dotoo_verbatim /^\s*>.*/
 syntax match  dotoo_code     /^\s*:.*/
-syntax region dotoo_verbatim start="^#+BEGIN_.*"      end="^#+END_.*"      keepend contains=dotoo_block_delimiter
-syntax region dotoo_code     start="^#+BEGIN_SRC"     end="^#+END_SRC"     keepend contains=dotoo_block_delimiter
-syntax region dotoo_code     start="^#+BEGIN_EXAMPLE" end="^#+END_EXAMPLE" keepend contains=dotoo_block_delimiter
+syntax region dotoo_verbatim start="^\s*#+BEGIN_.*"      end="^\s*#+END_.*"      keepend contains=dotoo_block_delimiter
+syntax region dotoo_code     start="^\s*#+BEGIN_SRC"     end="^\s*#+END_SRC"     keepend contains=dotoo_block_delimiter
+syntax region dotoo_code     start="^\s*#+BEGIN_EXAMPLE" end="^\s*#+END_EXAMPLE" keepend contains=dotoo_block_delimiter
 hi def link dotoo_code     String
 hi def link dotoo_verbatim String
 " }}}

--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -240,7 +240,6 @@ hi def link dotoo_list_def PreProc
 " Bullet Lists: {{{
 syntax match dotoo_list_item /.*$/ contained contains=dotoo_subtask_percent,dotoo_subtask_number,dotoo_subtask_percent_100,dotoo_subtask_number_all,dotoo_list_checkbox,dotoo_bold,dotoo_italic,dotoo_underline,dotoo_code,dotoo_verbatim,dotoo_timestamp,dotoo_timestamp_inactive,dotoo_list_def 
 syntax match dotoo_list_checkbox /\[[ X-]]/ contained
-hi def link dotoo_list_bullet Identifier
 hi def link dotoo_list_checkbox     PreProc
 
 " }}}


### PR DESCRIPTION
Since vim-dotoo was created, some changes were done to the syntax files of vim-orgmode, some of which bugfixes. I've backported them to vim-dotoo. I've backported these commits:
- [48ce285](https://github.com/jceb/vim-orgmode/commit/48ce285e937f32b658a2b9df60012ceb411ea185) clean up syntax highlighting of lists
- [32c155a](https://github.com/jceb/vim-orgmode/commit/32c155a5cc46ce354d0660a40d316b54ff69ef0c) use Ignore highlighting instead of NonText for shaded stars (closes issues #173)
- [b3b465a](https://github.com/jceb/vim-orgmode/commit/b3b465ad992fa69c2acd89c585f96ef4efe3212b) [SYNTAX] Fix syntax for #+BEGIN_* blocks
- [2d78966](https://github.com/jceb/vim-orgmode/commit/2d7896675b975b36717ea3d6612222a262b2120c) optimize checkbox regex to match also just the type without status and title
