### PR TITLE
Use default separator for timestamps

### DIFF
--- a/autoload/dotoo/parser/metadata.vim
+++ b/autoload/dotoo/parser/metadata.vim
@@ -5,7 +5,7 @@ let g:autoloaded_dotoo_parser_metadata = 1
 
 let s:metadata_methods = {}
 function! s:metadata_methods.serialize() dict
-  let [lsep, rsep] = [get(self, 'lsep', ''), get(self, 'rsep', '')]
+  let [lsep, rsep] = [get(self, 'lsep', '['), get(self, 'rsep', ']')]
   if has_key(self, 'deadline')
     return 'DEADLINE: ' . lsep . self.deadline.to_string() . rsep
   elseif has_key(self, 'scheduled')


### PR DESCRIPTION
I totally forgot about this one, it seems ...

When you closed an empty headline without timestamps, the date isn't surrounded by a separator. This commit fixes this.