### PR TITLE
Use new headline signatures

### DIFF
--- a/autoload/dotoo.vim
+++ b/autoload/dotoo.vim
@@ -12,10 +12,10 @@ function! dotoo#move_headline(headline)
   let target_title = input('Enter target: ', '', 'customlist,dotoo#agenda#headline_complete')
   redraw!
   let target_hl = dotoo#agenda#get_headline_by_title(target_title)
-  let splitted = a:headline.open()
+  call a:headline.open()
   call a:headline.delete()
   silent write
-  call a:headline.close(splitted)
+  call a:headline.close()
   if type(target_hl) == type({})
     call target_hl.add_headline(a:headline)
     call target_hl.save()


### PR DESCRIPTION
With commit 62f380fe738671acbbe39e59ef1cc6a403632859, the signature of open and close of headlines has changed. It wasn't propagated to all places, however, or it was simply not committed.

I fixed it at the time, but kind of forgot about it as I fixed on my branch with #24 and #29 merged.
