### PR TITLE
Fix #34

### DIFF
--- a/autoload/dotoo/time.vim
+++ b/autoload/dotoo/time.vim
@@ -113,7 +113,7 @@ function! s:to_seconds(time)
       let seconds += s:days_to_seconds(s:jd(y, m, d) - s:epoch_jd)
     endif
   endif
-  let seconds -= s:localtime().stzoffset
+  let seconds -= s:localtime(seconds).stzoffset
   return seconds
 endfunction
 


### PR DESCRIPTION
When I was looking at what was available in the time library, I saw what caused #34. When calculating the timestamp of a date, a timezone correction is done based on the current timezone. But in countries with DST, this is no constant. Using the result of the calculation up to then instead of the current time, the correct timezone on the date is calculated. Well, it might be wrong in the hours when changing the timezone. This can be checked using tests.

Anyway, this is a place where it might be interesting to use some Python instead of pure vimscript. It's sad vim does not provide anything for this, but the python does. It will probably be more efficient too.