### PR TITLE
Fix colors when no gui color is given

### DIFF
--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -94,7 +94,9 @@ if !exists('g:loaded_dotoo_syntax')
                   let l:found_gui_color = 1
                   let l:res_faces = l:res_faces . ' guifg=' . l:color
                 elseif l:color != ''
-                  let l:gui_color = l:color
+                  if l:color !~ '^\d\+$'
+                    let l:gui_color = l:color
+                  endif
                   let l:res_faces = l:res_faces . ' ctermfg=' . l:color
                 endif
               endfor
@@ -109,7 +111,9 @@ if !exists('g:loaded_dotoo_syntax')
                   let l:found_gui_color = 1
                   let l:res_faces = l:res_faces . ' guibg=' . l:color
                 elseif l:color != ''
-                  let l:gui_color = l:color
+                  if l:color !~ '^\d\+$'
+                    let l:gui_color = l:color
+                  endif
                   let l:res_faces = l:res_faces . ' ctermbg=' . l:color
                 endif
               endfor

--- a/syntax/dotooagenda.vim
+++ b/syntax/dotooagenda.vim
@@ -71,7 +71,9 @@ if !exists('g:loaded_dotooagenda_syntax')
                   let l:found_gui_color = 1
                   let l:res_faces = l:res_faces . ' guifg=' . l:color
                 elseif l:color != ''
-                  let l:gui_color = l:color
+                  if l:color !~ '^\d\+$'
+                    let l:gui_color = l:color
+                  endif
                   let l:res_faces = l:res_faces . ' ctermfg=' . l:color
                 endif
               endfor
@@ -86,7 +88,9 @@ if !exists('g:loaded_dotooagenda_syntax')
                   let l:found_gui_color = 1
                   let l:res_faces = l:res_faces . ' guibg=' . l:color
                 elseif l:color != ''
-                  let l:gui_color = l:color
+                  if l:color !~ '^\d\+$'
+                    let l:gui_color = l:color
+                  endif
                   let l:res_faces = l:res_faces . ' ctermbg=' . l:color
                 endif
               endfor


### PR DESCRIPTION
With vim 8.0.0022, it seems vim also checks if `guifg` and `guibg` are valid if you are using vim on the terminal with `notermguicolors`. Because of this, #38 is triggered when you use custom todo keywords without gui colors, even when terminal colors are used.