### PR TITLE
Fix saving of capture

### DIFF
--- a/ftplugin/dotoocapture.vim
+++ b/ftplugin/dotoocapture.vim
@@ -16,5 +16,5 @@ endfunction
 augroup BufWrite
   au!
 
-  autocmd BufLeave <buffer> call s:RefileAndClose()
+  autocmd BufHidden <buffer> call s:RefileAndClose()
 augroup END


### PR DESCRIPTION
Save capture when the buffer gets hidden instead of when it loses focus. This allows you to switch between windows while editing the capture buffer, without it being saved multiple times to your refile file.