### PR TITLE
Support for <C-A>  and <C-X> bindings in capture mode

### DIFF
--- a/ftplugin/dotoocapture.vim
+++ b/ftplugin/dotoocapture.vim
@@ -18,3 +18,5 @@ augroup BufWrite
 
   autocmd BufHidden <buffer> call s:RefileAndClose()
 augroup END
+nnoremap <buffer> <silent> <C-A> :<C-U>call dotoo#increment_date()<CR>
+nnoremap <buffer> <silent> <C-X> :<C-U>call dotoo#decrement_date()<CR>


### PR DESCRIPTION
Since the filetype is different these bindings are not always set. This allows users to change dates easily while in a capture.