### PR TITLE
added support for tpopes repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An awesome task manager & clocker inspired by org-mode written in pure viml.
    * <kbd>\<C-X\></kbd>:   Decrement date under cursor by 1 day, can be preceded with a [count]
    * <kbd>\<C-C\>\<C-C\></kbd>: Normalize a date (fixes day name if incorrect)
 
-   - The <kbd>\<C-X\></kbd>, <kbd>\<C-A\></kbd>, and  <kbd>cic</kbd> commands all work with <kbd>.</kbd>
+   The <kbd>\<C-X\></kbd>, <kbd>\<C-A\></kbd>, and  <kbd>cic</kbd> commands all work with <kbd>.</kbd>
    if you have [repeat.vim](http://github.com/tpope/vim-repeat) installed
 
    A few helpful `:iabbrev` :

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ An awesome task manager & clocker inspired by org-mode written in pure viml.
    * <kbd>\<C-X\></kbd>:   Decrement date under cursor by 1 day, can be preceded with a [count]
    * <kbd>\<C-C\>\<C-C\></kbd>: Normalize a date (fixes day name if incorrect)
 
+   - The <kbd>\<C-X\></kbd>, <kbd>\<C-A\></kbd>, and  <kbd>cic</kbd> commands all work with <kbd>.</kbd>
+   if you have [repeat.vim](http://github.com/tpope/vim-repeat) installed
+
    A few helpful `:iabbrev` :
    * `:date:` Enters the current date
    * `:time:` Enters the current date & time

--- a/autoload/dotoo.vim
+++ b/autoload/dotoo.vim
@@ -65,12 +65,14 @@ function! s:adjust_date(amount)
   endif
 endfunction
 
-function! dotoo#increment_date()
-  if !s:adjust_date('+'.v:count1.'d') | exe "normal! \<C-A>" | endif
+function! dotoo#increment_date(days)
+  if !s:adjust_date('+'.a:days.'d') | exe "normal! \<C-A>" | endif
+  silent! call repeat#set("\<Plug>DotooIncrementDate", a:days)
 endfunction
 
-function! dotoo#decrement_date()
-  if !s:adjust_date('-'.v:count1.'d') | exe "normal! \<C-X>" | endif
+function! dotoo#decrement_date(days)
+  if !s:adjust_date('-'.a:days.'d') | exe "normal! \<C-X>" | endif
+  silent! call repeat#set("\<Plug>DotooDecrementDate", a:days)
 endfunction
 
 let s:syntax = dotoo#parser#lexer#syntax()

--- a/autoload/dotoo/checkbox.vim
+++ b/autoload/dotoo/checkbox.vim
@@ -105,4 +105,5 @@ function! dotoo#checkbox#toggle()
     call s:process_parents(nline)
   endif
   call setpos('.', pos)
+  silent! call repeat#set("\<Plug>DotooCheckboxToggle")
 endfunction

--- a/ftplugin/dotoo.vim
+++ b/ftplugin/dotoo.vim
@@ -32,11 +32,15 @@ autocmd! BufWritePost <buffer> call dotoo#parser#parsefile({'force': 1})
 iabbrev <expr> <buffer> <silent> :date: '['.strftime(g:dotoo#time#date_day_format).']'
 iabbrev <expr> <buffer> <silent> :time: '['.strftime(g:dotoo#time#datetime_format).']'
 
-nnoremap <buffer> <silent> gI :<C-U>call dotoo#clock#start()<CR>
-nnoremap <buffer> <silent> gO :<C-U>call dotoo#clock#stop()<CR>
-nnoremap <buffer> <silent> gM :<C-U>call dotoo#move_headline(dotoo#get_headline())<CR>
-nnoremap <buffer> <silent> cit :<C-U>call dotoo#change_todo()<CR>
-nnoremap <buffer> <silent> cic :<C-U>call dotoo#checkbox#toggle()<CR>
-nnoremap <buffer> <silent> <C-A> :<C-U>call dotoo#increment_date()<CR>
-nnoremap <buffer> <silent> <C-X> :<C-U>call dotoo#decrement_date()<CR>
+nnoremap <silent> <Plug>DotooIncrementDate  :<C-U>call dotoo#increment_date(v:count1)<CR>
+nnoremap <silent> <Plug>DotooDecrementDate  :<C-U>call dotoo#decrement_date(v:count1)<CR>
+nnoremap <silent> <Plug>DotooCheckboxToggle :<C-U>call dotoo#checkbox#toggle()<CR>
+
+nnoremap <buffer> <silent> gI         :<C-U>call dotoo#clock#start()<CR>
+nnoremap <buffer> <silent> gO         :<C-U>call dotoo#clock#stop()<CR>
+nnoremap <buffer> <silent> gM         :<C-U>call dotoo#move_headline(dotoo#get_headline())<CR>
+nnoremap <buffer> <silent> cit        :<C-U>call dotoo#change_todo()<CR>
 nnoremap <buffer> <silent> <C-C><C-C> :<C-U>call dotoo#normalize()<CR>
+nmap     <buffer> cic      <Plug>DotooCheckboxToggle
+nmap     <buffer> <C-A>    <Plug>DotooIncrementDate
+nmap     <buffer> <C-X>    <Plug>DotooDecrementDate

--- a/ftplugin/dotoo.vim
+++ b/ftplugin/dotoo.vim
@@ -32,10 +32,6 @@ autocmd! BufWritePost <buffer> call dotoo#parser#parsefile({'force': 1})
 iabbrev <expr> <buffer> <silent> :date: '['.strftime(g:dotoo#time#date_day_format).']'
 iabbrev <expr> <buffer> <silent> :time: '['.strftime(g:dotoo#time#datetime_format).']'
 
-nnoremap <silent> <Plug>DotooIncrementDate  :<C-U>call dotoo#increment_date(v:count1)<CR>
-nnoremap <silent> <Plug>DotooDecrementDate  :<C-U>call dotoo#decrement_date(v:count1)<CR>
-nnoremap <silent> <Plug>DotooCheckboxToggle :<C-U>call dotoo#checkbox#toggle()<CR>
-
 nnoremap <buffer> <silent> gI         :<C-U>call dotoo#clock#start()<CR>
 nnoremap <buffer> <silent> gO         :<C-U>call dotoo#clock#stop()<CR>
 nnoremap <buffer> <silent> gM         :<C-U>call dotoo#move_headline(dotoo#get_headline())<CR>

--- a/ftplugin/dotoocapture.vim
+++ b/ftplugin/dotoocapture.vim
@@ -18,5 +18,8 @@ augroup BufWrite
 
   autocmd BufHidden <buffer> call s:RefileAndClose()
 augroup END
-nnoremap <buffer> <silent> <C-A> :<C-U>call dotoo#increment_date()<CR>
-nnoremap <buffer> <silent> <C-X> :<C-U>call dotoo#decrement_date()<CR>
+
+nnoremap <silent> <Plug>DotooIncrementDate :<C-U>call dotoo#increment_date(v:count1)<CR>
+nnoremap <silent> <Plug>DotooDecrementDate :<C-U>call dotoo#decrement_date(v:count1)<CR>
+nmap <buffer> <C-A> <Plug>DotooIncrementDate
+nmap <buffer> <C-X> <Plug>DotooIncrementDate

--- a/ftplugin/dotoocapture.vim
+++ b/ftplugin/dotoocapture.vim
@@ -19,7 +19,6 @@ augroup BufWrite
   autocmd BufHidden <buffer> call s:RefileAndClose()
 augroup END
 
-nnoremap <silent> <Plug>DotooIncrementDate :<C-U>call dotoo#increment_date(v:count1)<CR>
-nnoremap <silent> <Plug>DotooDecrementDate :<C-U>call dotoo#decrement_date(v:count1)<CR>
 nmap <buffer> <C-A> <Plug>DotooIncrementDate
 nmap <buffer> <C-X> <Plug>DotooIncrementDate
+nmap <buffer> cic   <Plug>DotooCheckboxToggle

--- a/plugin/dotoo.vim
+++ b/plugin/dotoo.vim
@@ -64,3 +64,7 @@ call dotoo#agenda_views#refiles#register()
 
 " Register Agenda View Plugins
 call dotoo#agenda_views#plugins#log_summary#register()
+
+nnoremap <silent> <Plug>DotooIncrementDate  :<C-U>call dotoo#increment_date(v:count1)<CR>
+nnoremap <silent> <Plug>DotooDecrementDate  :<C-U>call dotoo#decrement_date(v:count1)<CR>
+nnoremap <silent> <Plug>DotooCheckboxToggle :<C-U>call dotoo#checkbox#toggle()<CR>


### PR DESCRIPTION
I added support for tpopes [repeat.vim](https://github.com/tpope/vim-repeat) plugin to <kbd>\<C-X\></kbd>, <kbd>\<C-A\></kbd>, and  <kbd>cic</kbd> .
