### PR TITLE
Support for embedded latex conceal

### DIFF
--- a/doc/dotoo.txt
+++ b/doc/dotoo.txt
@@ -203,6 +203,16 @@ OPTIONS                                                          *dotoo-options*
             captures templates into. >
                 let g:dotoo#capture#refile = expand('~/Documents/dotoo-files/refile.dotoo')
 <
+                                                      *g:dotoo#capture#files*
+      |g:dotoo#capture#files|
+            This setting defines the a specific file to store a specific 
+			capture template if none are set g:dotoo#capture#refile is used. >
+			let g:dotoo#capture#files = [
+				\ ['t', 'Todo', '~/Documents/dotoo-files/gym.dotoo'],
+				\ ['m', 'Meeting', '~/Documents/dotoo-files/refile.dotoo']
+				\ ]
+
+<
                                                          *g:dotoo#capture#clock*
       |g:dotoo#capture#clock|
             This setting enables clocking while capturing. >

--- a/doc/dotoo.txt
+++ b/doc/dotoo.txt
@@ -205,8 +205,8 @@ OPTIONS                                                          *dotoo-options*
 <
                                                       *g:dotoo#capture#files*
       |g:dotoo#capture#files|
-            This setting defines the a specific file to store a specific 
-			capture template if none are set g:dotoo#capture#refile is used. >
+            This setting defines the a specific file to store a specific capture 
+            template if none are set g:dotoo#capture#refile is used. >
 			let g:dotoo#capture#files = [
 				\ ['t', 'Todo', '~/Documents/dotoo-files/gym.dotoo'],
 				\ ['m', 'Meeting', '~/Documents/dotoo-files/refile.dotoo']

--- a/ftplugin/dotoocapture.vim
+++ b/ftplugin/dotoocapture.vim
@@ -8,7 +8,7 @@ function! s:RefileAndClose()
   let headline = dotoo.headlines[0]
   if g:dotoo#capture#clock | call dotoo#clock#stop(headline) | endif
   set nomodified
-  silent exe 'keepalt' 'split' g:dotoo#capture#refile
+  silent exe 'keepalt' 'split' g:dotoo#capture#refile_to
   call append('$', headline.serialize())
   wq
 endfunction


### PR DESCRIPTION
When using `$latex math$` or `$$ latex math $$` the conceal properties that usually apply to .tex files is used within the block. This is meant to mimic the latex preview feature from org mode. 