### PR TITLE
Lazy load agenda

### DIFF
--- a/autoload/dotoo/agenda.vim
+++ b/autoload/dotoo/agenda.vim
@@ -286,7 +286,7 @@ function! dotoo#agenda#filter_complete(A,L,P)
   return filter(ops, 'v:val =~? a:A')
 endfunction
 
-function! s:dotoo#agenda#load()
+function! dotoo#agenda#load()
   let s:dotoo_agenda_loaded = 1
   " Register Agenda Views
   call dotoo#agenda_views#todos#register()

--- a/autoload/dotoo/agenda.vim
+++ b/autoload/dotoo/agenda.vim
@@ -286,8 +286,23 @@ function! dotoo#agenda#filter_complete(A,L,P)
   return filter(ops, 'v:val =~? a:A')
 endfunction
 
+function! s:dotoo#agenda#load()
+  let s:dotoo_agenda_loaded = 1
+  " Register Agenda Views
+  call dotoo#agenda_views#todos#register()
+  call dotoo#agenda_views#notes#register()
+  call dotoo#agenda_views#agenda#register()
+  call dotoo#agenda_views#refiles#register()
+  
+  " Register Agenda View Plugins
+  call dotoo#agenda_views#plugins#log_summary#register()
+endfunction
+
 let s:current_view = ''
 function! dotoo#agenda#agenda()
+  if !exists('s:dotoo_agenda_loaded')
+  	call dotoo#agenda#load()
+  endif
   let force = 1
   let old_view = s:current_view
   let s:current_view = s:agenda_views_menu()

--- a/plugin/dotoo.vim
+++ b/plugin/dotoo.vim
@@ -52,18 +52,8 @@ endif
 
 augroup dotoo
   au!
-
   autocmd FileType dotoo call dotoo#parser#parsefile({'force': 1})
 augroup END
-
-" Register Agenda Views
-call dotoo#agenda_views#todos#register()
-call dotoo#agenda_views#notes#register()
-call dotoo#agenda_views#agenda#register()
-call dotoo#agenda_views#refiles#register()
-
-" Register Agenda View Plugins
-call dotoo#agenda_views#plugins#log_summary#register()
 
 nnoremap <silent> <Plug>DotooIncrementDate  :<C-U>call dotoo#increment_date(v:count1)<CR>
 nnoremap <silent> <Plug>DotooDecrementDate  :<C-U>call dotoo#decrement_date(v:count1)<CR>


### PR DESCRIPTION
Instead of loading the agenda at startup load it when the agenda is actually called this substantially improves startup time. Loading dotoo now takes one sixth the time when starting up Vim. There is also the option for the user to now also call dotoo#agenda#load() if they would like to load it before hand.
