### PR TITLE
added latex math syntax

### DIFF
--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -309,6 +309,7 @@ if exists('g:loaded_SyntaxRange')
   call SyntaxRange#Include('\\begin[.*]{.*}', '\\end{.*}', 'tex')
   call SyntaxRange#Include('\\begin{.*}', '\\end{.*}', 'tex')
   call SyntaxRange#Include('\\\[', '\\\]', 'tex')
+  call SyntaxRange#Include('\$[^$]', '\$', 'tex')
 endif
 " }}}
 


### PR DESCRIPTION
Added support for short latex math equations surrounded in $$. Credit goes to the vim-orgmode project for this one.