### PR TITLE
Urls in headings are more readable

### DIFF
--- a/ftplugin/dotoo.vim
+++ b/ftplugin/dotoo.vim
@@ -9,10 +9,10 @@ setl foldmethod=expr
 setl foldtext=DotooFoldText()
 
 function! DotooFoldText()
-	let line = getline(v:foldstart)
-	let sub = substitute(line,'[[.\{-}\][\(.\{-}\)', '', 'g' )
-	let sub = substitute(sub,']]', '', 'g' )
-	return sub
+  let line = getline(v:foldstart)
+  let sub = substitute(line,'[[.\{-}\][\(.\{-}\)', '', 'g' )
+  let sub = substitute(sub,']]', '', 'g' )
+  return sub
 endfunction
 
 let s:syntax = dotoo#parser#lexer#syntax()

--- a/ftplugin/dotoo.vim
+++ b/ftplugin/dotoo.vim
@@ -6,7 +6,14 @@ let b:did_ftplugin = 1
 setl commentstring=#\ %s
 setl foldexpr=DotooFoldExpr()
 setl foldmethod=expr
-setl foldtext=getline(v:foldstart)
+setl foldtext=DotooFoldText()
+
+function! DotooFoldText()
+	let line = getline(v:foldstart)
+	let sub = substitute(line,'[[.\{-}\][\(.\{-}\)', '', 'g' )
+	let sub = substitute(sub,']]', '', 'g' )
+	return sub
+endfunction
 
 let s:syntax = dotoo#parser#lexer#syntax()
 function! DotooFoldExpr()


### PR DESCRIPTION
if a url of the format [[https://url.com][url description]] is in a heading the conceal is nolonger applied. This pullrequest fixes this by removing the url and leaves the description when a heading is folded to make it more readable.

from
![2020-06-25_11:56:18](https://user-images.githubusercontent.com/34443260/85773416-0cf99e00-b6db-11ea-9c7d-021c9aa1da7c.png)

to

![2020-06-25_11:55:42](https://user-images.githubusercontent.com/34443260/85773384-0408cc80-b6db-11ea-90e6-d6d8dcd42ceb.png)

