### PR TITLE
Allow for urls to properly fold in headlines

### DIFF
--- a/autoload/dotoo/parser/lexer.vim
+++ b/autoload/dotoo/parser/lexer.vim
@@ -30,7 +30,7 @@ let s:todo_keywords_done = g:dotoo#parser#todo_keywords[index(g:dotoo#parser#tod
 let s:todo_keywords_regex = join(s:todo_keywords_todo+s:todo_keywords_done, '|')
 call s:define('blank', '\v^$')
 call s:define('directive', '\v^#\+(\w+): (.*)$')
-call s:define('headline', '\v^(\*+)\s?('.s:todo_keywords_regex.')?\s?(\[\d+\])? ([^:]*)( :.*:)?$')
+call s:define('headline', '\v^(\*+)\s?('.s:todo_keywords_regex.')?\s?(\[\d+\])? (.*)( :.*:)?$')
 call s:define('metadata', '\v^(DEADLINE|CLOSED|SCHEDULED): ([\<\[])(.*)([\>\]])$')
 call s:define('properties', '\v^:PROPERTIES:$')
 call s:define('logbook', '\v^:LOGBOOK:$')


### PR DESCRIPTION
correct me if I am wrong but I cant see any issues with allowing `:` in a heading. this will allow for urls with https://... to exist in a heading and get proper folding. Otherwise the heading is improperly parsed.