### PR TITLE
Convert the custom dialog system to use `confirm()`

### DIFF
--- a/autoload/dotoo/agenda.vim
+++ b/autoload/dotoo/agenda.vim
@@ -35,12 +35,11 @@ endfunction
 
 function! s:agenda_views_menu()
   let views = keys(s:agenda_views)
-  let acceptable_input = '['.join(copy(views),'').']'
-  call map(views, '"(".s:agenda_views[v:val].key.") ".s:agenda_views[v:val].name')
-  call add(views, 'Select agenda view: ')
-  let selected = dotoo#utils#getchar(join(views, "\n"), acceptable_input)
+  call map(views, '"&".s:agenda_views[v:val].key." ".s:agenda_views[v:val].name')
+  let confnum = confirm('Select agenda view: ', join(views, "\n") )
   let sel = []
-  if !empty(selected)
+  if confnum != 0
+    let selected = keys(s:agenda_views)[confnum - 1]
     let sel = s:agenda_views[selected]
   endif
   return !empty(sel) ? sel : {}


### PR DESCRIPTION
This should provide better longterm stability and help save some of the headache involved in using a custom solution. One of the biggest advantages is that it can support all terminal sizes. 