### PR TITLE
Allow default mappings to be disabled.

### DIFF
--- a/doc/dotoo.txt
+++ b/doc/dotoo.txt
@@ -45,7 +45,8 @@ GETTING STARTED                                           *dotoo-getting-started
       1. Document Structure: The docment structure is borrowed from emacs'
          Org Mode.
 
-         These are the dotoo document mappings :
+         These are the default dotoo document mappings (which can be turned off
+         using |g:dotoo_use_default_mappings|) :
               `gI`:         clock-in headline under cursor
               `gO`:         clock-out headline under cursor
               `gM`:         move headline under cursor to selected target
@@ -141,6 +142,21 @@ OPTIONS                                                          *dotoo-options*
             This setting defines whether the leading stars of the headlines
             will be shaded. Set this to 0 if you don't want them to be shaded. >
                 let g:dotoo_headline_shade_leading_stars = 1
+<
+                                                  *g:dotoo_use_default_mappings*
+      |g:dotoo_use_default_mappings|
+            This setting defaults to 1, and disables the default dotoo file
+            mappings when set to 0. These mappings can be manually rebound and
+            customized, as shown below. >
+                let g:dotoo_use_default_mappings = 0
+                nmap <buffer> gI          <Plug>DotooClockIn
+                nmap <buffer> gO          <Plug>DotooClockOut
+                nmap <buffer> gM          <Plug>DotooMoveHeadline
+                nmap <buffer> cit         <Plug>DotooChangeTodo
+                nmap <buffer> <C-C><C-C>  <Plug>DotooNormalizeDate
+                nmap <buffer> cic         <Plug>DotooCheckboxToggle
+                nmap <buffer> <C-A>       <Plug>DotooIncrementDate
+                nmap <buffer> <C-X>       <Plug>DotooDecrementDate
 <
                                                   *g:dotoo_todo_keyword_faces*
       |g:dotoo_todo_keyword_faces|

--- a/ftplugin/dotoo.vim
+++ b/ftplugin/dotoo.vim
@@ -3,6 +3,10 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
+if !exists('g:dotoo_use_default_mappings')
+  let g:dotoo_use_default_mappings = 1
+endif
+
 setl commentstring=#\ %s
 setl foldexpr=DotooFoldExpr()
 setl foldmethod=expr
@@ -33,13 +37,21 @@ autocmd! BufWritePost <buffer> call dotoo#parser#parsefile({'force': 1})
 iabbrev <expr> <buffer> <silent> :date: '['.strftime(g:dotoo#time#date_day_format).']'
 iabbrev <expr> <buffer> <silent> :time: '['.strftime(g:dotoo#time#datetime_format).']'
 
-nnoremap <buffer> <silent> gI         :<C-U>call dotoo#clock#start()<CR>
-nnoremap <buffer> <silent> gO         :<C-U>call dotoo#clock#stop()<CR>
-nnoremap <buffer> <silent> gM         :<C-U>call dotoo#move_headline_menu(dotoo#get_headline())<CR>
-nnoremap <buffer> <silent> cit        :<C-U>call dotoo#change_todo()<CR>
-nnoremap <buffer> <silent> <C-C><C-C> :<C-U>call dotoo#normalize()<CR>
-nmap     <buffer> cic      <Plug>DotooCheckboxToggle
-nmap     <buffer> <C-A>    <Plug>DotooIncrementDate
-nmap     <buffer> <C-X>    <Plug>DotooDecrementDate
+nnoremap <buffer> <silent> <Plug>DotooClockIn       :<C-U>call dotoo#clock#start()<CR>
+nnoremap <buffer> <silent> <Plug>DotooClockOut      :<C-U>call dotoo#clock#stop()<CR>
+nnoremap <buffer> <silent> <Plug>DotooMoveHeadline  :<C-U>call dotoo#move_headline_menu(dotoo#get_headline())<CR>
+nnoremap <buffer> <silent> <Plug>DotooChangeTodo    :<C-U>call dotoo#change_todo()<CR>
+nnoremap <buffer> <silent> <Plug>DotooNormalizeDate :<C-U>call dotoo#normalize()<CR>
+
+if g:dotoo_use_default_mappings
+  nmap <buffer> gI          <Plug>DotooClockIn
+  nmap <buffer> gO          <Plug>DotooClockOut
+  nmap <buffer> gM          <Plug>DotooMoveHeadline
+  nmap <buffer> cit         <Plug>DotooChangeTodo
+  nmap <buffer> <C-C><C-C>  <Plug>DotooNormalizeDate
+  nmap <buffer> cic         <Plug>DotooCheckboxToggle
+  nmap <buffer> <C-A>       <Plug>DotooIncrementDate
+  nmap <buffer> <C-X>       <Plug>DotooDecrementDate
+endif
 
 command! -buffer -nargs=? DotooAdjustDate call dotoo#adjust_date(<q-args>)


### PR DESCRIPTION
I took a shot at #95:

*       Abstract some mappings under <Plug>Dotoo*
*       Introduce new setting g:dotoo_use_default_mapping which can be
        used to disable default mappings.

Please let me know what you think!