### PR TITLE
Prevent creating extraneous "refile" files

### DIFF
--- a/autoload/dotoo/capture.vim
+++ b/autoload/dotoo/capture.vim
@@ -12,7 +12,6 @@ call dotoo#utils#set('dotoo#capture#templates', {
       \     '* TODO %?',
       \     'DEADLINE: [%(strftime(g:dotoo#time#datetime_format))]'
       \   ],
-      \  'target': 'refile'
       \ },
       \ 'n': {
       \   'description': 'Note',


### PR DESCRIPTION
If using a non standard `dotoo#capture#refile` path and overriding the template for `t` without overriding `'target':`, capturing a new Todo creates a new `refile` file in the current directory. Removing this line seems to prevent creating those files and allow the capture to be saved to the file specified in `dotoo#caputure#refile`