### PR TITLE
Include file name in headline even if it's not a full match.

### DIFF
--- a/autoload/dotoo/agenda.vim
+++ b/autoload/dotoo/agenda.vim
@@ -214,7 +214,7 @@ function! dotoo#agenda#headline_complete(ArgLead, CmdLine, CursorPos)
   for key in keys(s:agenda_dotoos)
     let _key = fnamemodify(key, ':p:t:r')
     if empty(a:ArgLead) || _key =~# '^'.a:ArgLead[:stridx(a:ArgLead, ':')-1]
-      if _key ==# a:ArgLead
+      if _key =~# '^'.a:ArgLead
         call add(headlines, _key)
       endif
       let dotoo = s:agenda_dotoos[key]


### PR DESCRIPTION
I'm mostly moving things from refile to the top level of the file, and autocomplete never completes those for me unless I completely type it. This fix allows autocompleting both headlines inside and the file name for the top level.