### PR TITLE
Add support for deadline warning. Fixes #111.

### DIFF
--- a/autoload/dotoo/parser/headline.vim
+++ b/autoload/dotoo/parser/headline.vim
@@ -89,7 +89,7 @@ function! s:headline_methods.is_due(date) dict
   let ddate = self.deadline()
   if a:date.is_today() && self.is_deadline()
     let warning_limit = a:date.adjust(g:dotoo#agenda#warning_days)
-    return ddate.before(warning_limit)
+    return ddate.before(warning_limit) || ddate.warning_date().eq_date(a:date)
   else
     return self.is_due_by(a:date)
   endif

--- a/autoload/dotoo/time.vim
+++ b/autoload/dotoo/time.vim
@@ -53,10 +53,11 @@ endfunction
 
 function! s:localtime(...)
   let ts  = a:0 && !empty(a:1) ? a:1 : localtime()
-  let rp = a:0 == 2 && !empty(a:2) ? a:2 : ''
+  let adjustment = a:0 == 2 && !empty(a:2) ? a:2 : ''
+  let rp = adjustment
   let warning = ''
   if s:is_repeat_negative(rp)
-    let warning = rp
+    let warning = adjustment
     let rp = ''
   endif
 
@@ -79,6 +80,7 @@ function! s:localtime(...)
         \, 'second' : +strftime('%S', ts)
         \, 'sepoch' : sepoch
         \, 'repeat' : rp
+        \, 'adjustment': adjustment
         \, 'warning' : warning
         \}
   let datetime.depoch = s:jd(datetime.year, datetime.month, datetime.day)
@@ -279,25 +281,25 @@ endfunction
 
 function! s:time_methods.to_string(...) dict
   let format = a:0 && !empty(a:1) ? a:1 : g:dotoo#time#date_day_format
-  let include_repeat = a:0 == 2 ? a:2 : 1
+  let include_adjustment = a:0 == 2 ? a:2 : 1
   if format ==# g:dotoo#time#date_day_format && strftime(g:dotoo#time#time_format, self.to_seconds()) !=# '00:00'
     let format = g:dotoo#time#datetime_format
   endif
   let str = strftime(format, self.to_seconds())
-  if include_repeat && !empty(self.datetime.repeat)
-    let str .= ' ' . self.datetime.repeat
+  if include_adjustment && !empty(self.datetime.adjustment)
+    let str .= ' ' . self.datetime.adjustment
   endif
   return str
 endfunction
 
 function! s:time_methods.add(other) dict
   let datetime = self.to_seconds() + a:other.to_seconds()
-  return dotoo#time#new(datetime, self.datetime.repeat)
+  return dotoo#time#new(datetime, self.datetime.adjustment)
 endfunction
 
 function! s:time_methods.sub(other) dict
   let datetime = self.to_seconds() - a:other.to_seconds()
-  return dotoo#time#new(datetime, self.datetime.repeat)
+  return dotoo#time#new(datetime, self.datetime.adjustment)
 endfunction
 
 function! s:time_methods.adjust(amount) dict
@@ -339,7 +341,7 @@ function! s:time_methods.adjust(amount) dict
   if ! adjusted
     let datetime = s:localtime(self.datetime.to_seconds() + seconds)
   endif
-  return dotoo#time#new(datetime, self.datetime.repeat)
+  return dotoo#time#new(datetime, self.datetime.adjustment)
 endfunction
 
 function! s:time_methods.next_repeat() dict

--- a/dotoo.dotoo
+++ b/dotoo.dotoo
@@ -16,6 +16,8 @@ DEADLINE: <2014-08-03 Sun 18:00>
 DEADLINE: <2014-07-28 Mon 14:23>
 * TODO Test Task with Repeatable Deadline
 DEADLINE: [2014-07-28 Mon 14:23 +1m]
+* TODO Test Task with Deadline and warning
+DEADLINE: [2014-07-28 Mon 14:23 -1d]
 * DONE Add documentation
 CLOSED: [2014-07-02 Wed 20:45]
 * DONE Actual headline tree

--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -188,10 +188,10 @@ unlet! s:todo_headings
 syn match dotoo_timestamp /\([\<\[]\d\d\d\d-\d\d-\d\d \a\a\a[\>\]]\)/
 "[2003-09-16 Tue 12:00] | <2003-09-16 Tue 12:00>
 syn match dotoo_timestamp /\([\<\[]\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d[\>\]]\)/
-"[2003-09-16 Tue +1m] | <2003-09-16 Tue +1m>
-syn match dotoo_timestamp /\([\<\[]\d\d\d\d-\d\d-\d\d \a\a\a +\d\+[ymwdhs][\>\]]\)/
-"[2003-09-15 Tue 12:00 +1m] | <2003-09-16 Tue 12:00 +1m>
-syn match dotoo_timestamp /\([\<\[]\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d +\d\+[ymwdhs][\>\]]\)/
+"[2003-09-16 Tue +1m] | <2003-09-16 Tue +1m> | [2003-09-16 Tue -1m] | <2003-09-16 Tue -1m>
+syn match dotoo_timestamp /\([\<\[]\d\d\d\d-\d\d-\d\d \a\a\a [+-]\d\+[ymwdhs][\>\]]\)/
+"[2003-09-15 Tue 12:00 +1m] | <2003-09-16 Tue 12:00 +1m> [2003-09-15 Tue 12:00 -1m] | <2003-09-16 Tue 12:00 -1m>
+syn match dotoo_timestamp /\([\<\[]\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d [+-]\d\+[ymwdhs][\>\]]\)/
 "[2003-09-16 Tue]--[2003-09-16 Tue]
 syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a\]--\[\d\d\d\d-\d\d-\d\d \a\a\a\]\)/
 "[2003-09-16 Tue 12:00]--[2003-09-16 Tue 12:00]
@@ -223,7 +223,7 @@ hi def link dotoo_comment Comment
 " Ordered Lists:
 " 1. list item
 " 1) list item
-syn match dotoo_list_ordered "^\s*\(\a\|\d\+\)[.)]\(\s\|$\)" nextgroup=dotoo_list_item 
+syn match dotoo_list_ordered "^\s*\(\a\|\d\+\)[.)]\(\s\|$\)" nextgroup=dotoo_list_item
 hi def link dotoo_list_ordered Identifier
 
 " Unordered Lists:
@@ -231,7 +231,7 @@ hi def link dotoo_list_ordered Identifier
 " * list item
 " + list item
 " + and - don't need a whitespace prefix
-syn match dotoo_list_unordered "^\(\s*[-+]\|\s\+\*\)\(\s\|$\)" nextgroup=dotoo_list_item 
+syn match dotoo_list_unordered "^\(\s*[-+]\|\s\+\*\)\(\s\|$\)" nextgroup=dotoo_list_item
 hi def link dotoo_list_unordered Identifier
 
 " Definition Lists:
@@ -242,7 +242,7 @@ hi def link dotoo_list_def PreProc
 "
 " }}}
 " Bullet Lists: {{{
-syntax match dotoo_list_item /.*$/ contained contains=dotoo_subtask_percent,dotoo_subtask_number,dotoo_subtask_percent_100,dotoo_subtask_number_all,dotoo_list_checkbox,dotoo_bold,dotoo_italic,dotoo_underline,dotoo_code,dotoo_verbatim,dotoo_timestamp,dotoo_timestamp_inactive,dotoo_list_def 
+syntax match dotoo_list_item /.*$/ contained contains=dotoo_subtask_percent,dotoo_subtask_number,dotoo_subtask_percent_100,dotoo_subtask_number_all,dotoo_list_checkbox,dotoo_bold,dotoo_italic,dotoo_underline,dotoo_code,dotoo_verbatim,dotoo_timestamp,dotoo_timestamp_inactive,dotoo_list_def
 syntax match dotoo_list_checkbox /\[[ X-]]/ contained
 hi def link dotoo_list_checkbox     PreProc
 

--- a/syntax/dotooagenda.vim
+++ b/syntax/dotooagenda.vim
@@ -170,10 +170,10 @@ syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d-\d\d:\d\d\]\)
 syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a\]--\[\d\d\d\d-\d\d-\d\d \a\a\a\]\)/
 "\[2003-09-16 Tue 12:00\]--[2003-09-16 Tue 12:00]
 syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d\]--\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d\]\)/
-"[2003-09-16 Tue +1m]
-syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a +\d\+[ymwdhs]\]\)/
-"[2003-09-15 Tue 12:00 +1m]
-syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d +\d\+[ymwdhs]\]\)/
+"[2003-09-16 Tue +1m] | [2003-09-16 Tue -1m]
+syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a [+-]\d\+[ymwdhs]\]\)/
+"[2003-09-15 Tue 12:00 +1m] | [2003-09-15 Tue 12:00 -1m]
+syn match dotoo_timestamp /\(\[\d\d\d\d-\d\d-\d\d \a\a\a \d\d:\d\d [+-]\d\+[ymwdhs]\]\)/
 
 syn match dotoo_timestamp /\(\[%%(diary-float.\+\]\)/
 hi def link dotoo_timestamp SpecialKey

--- a/t/autoload/dotoo/parser_test.vim
+++ b/t/autoload/dotoo/parser_test.vim
@@ -1,7 +1,7 @@
 function! s:TestHeadlines()
   let dotoos = dotoo#parser#parsefile({'file': 't/fixtures/sample.dotoo'})
   call testify#assert#equals(dotoos.file, 't/fixtures/sample.dotoo')
-  call testify#assert#equals(len(dotoos.headlines), 18)
+  call testify#assert#equals(len(dotoos.headlines), 19)
 endfunction
 call testify#it('Should parse headlines', function('s:TestHeadlines'))
 
@@ -16,9 +16,9 @@ call testify#it('Should have right directives', function('s:TestDirectives'))
 function! s:TestFilter()
   let dotoos = dotoo#parser#parsefile({'file': 't/fixtures/sample.dotoo'})
   call testify#assert#equals(len(dotoos.filter('v:val.done()')), 7)
-  call testify#assert#equals(len(dotoos.filter('v:val.todo ==# "TODO"')), 11)
+  call testify#assert#equals(len(dotoos.filter('v:val.todo ==# "TODO"')), 12)
   call testify#assert#equals(len(dotoos.filter('v:val.todo ==# "CANCELLED"')), 1)
   call testify#assert#equals(len(dotoos.filter('empty(v:val.metadate())')), 8)
-  call testify#assert#equals(len(dotoos.filter('!empty(v:val.metadate()) && !v:val.done()')), 3)
+  call testify#assert#equals(len(dotoos.filter('!empty(v:val.metadate()) && !v:val.done()')), 4)
 endfunction
 call testify#it('Should filter dotoos', function('s:TestFilter'))

--- a/t/fixtures/sample.dotoo
+++ b/t/fixtures/sample.dotoo
@@ -16,6 +16,8 @@ DEADLINE: <2014-08-03 Sun 18:00>
 DEADLINE: <2014-07-28 Mon 14:23>
 * TODO Test Task with Repeatable Deadline
 DEADLINE: [2014-07-28 Mon 14:23 +1m]
+* TODO Test Task with Deadline and warning
+DEADLINE: [2014-07-28 Mon 14:23 -1d]
 * DONE Add documentation
 CLOSED: [2014-07-02 Wed 20:45]
 * DONE Actual headline tree


### PR DESCRIPTION
This is the attempt to support deadline warnings initially mentioned in #111. I'm not sure if I missed something, but from what I tested everything works fine.

Advantages:
* Allows setting warnings above and below defined `g:dotoo#agenda#warning_days`
* Better support with other org mode and other tools ([Orgzly](http://www.orgzly.com/) in my case)