### PR TITLE
Add basic support for block src filetypes.

### DIFF
--- a/doc/dotoo.txt
+++ b/doc/dotoo.txt
@@ -173,6 +173,15 @@ OPTIONS                                                          *dotoo-options*
                   \ ['PHONE', [':foreground 22', ':weight bold']]
                   \ ]
 <
+                                                  *g:dotoo_begin_src_languages*
+      |g:dotoo_begin_src_languages|
+            List of filetypes that should be highlighted in `#+BLOCK_SRC filetype`
+            code blocks.
+            Example. >
+                let g:dotoo_todo_keyword_faces = ['vim', 'json', 'javascript']
+<
+            Default value: `[]`
+
                                                 *g:dotoo#parser#todo_keywords*
       |g:dotoo#parser#todo_keywords|
             This setting defines various todo keywords to be recognized. A `|`

--- a/syntax/dotoo.vim
+++ b/syntax/dotoo.vim
@@ -19,6 +19,24 @@ if exists('b:current_syntax')
   finish
 endif
 
+
+if !exists('g:dotoo_begin_src_languages')
+  let g:dotoo_begin_src_languages = []
+endif
+let s:valid_begin_src_languages = map(copy(g:dotoo_begin_src_languages), 'matchstr(v:val, "[^.]*")')
+
+let s:included_src_languages = {}
+for s:lang in s:valid_begin_src_languages
+  if has_key(s:included_src_languages, s:lang)
+    continue
+  endif
+  exe printf('syntax include @dotooBlockSrc%s syntax/%s.vim', s:lang, s:lang)
+  unlet! b:current_syntax
+  let s:included_src_languages[s:lang] = 1
+endfor
+unlet! s:lang
+unlet! s:included_src_languages
+
 " FIXME: Always make dotoo_bold syntax define before dotoo_heading syntax
 "        to make sure that dotoo_heading syntax got higher priority(help :syn-priority) than dotoo_bold.
 "        If there is any other good solution, please help fix it.
@@ -289,28 +307,15 @@ hi def link dotoo_subtask_percent String
 hi def link dotoo_subtask_percent_100 Identifier
 hi def link dotoo_subtask_number_all Identifier
 
-" }}}
-" Plugin SyntaxRange: {{{
-" This only works if you have SyntaxRange installed:
-" https://github.com/vim-scripts/SyntaxRange
-
-" BEGIN_SRC
-if exists('g:loaded_SyntaxRange')
-  call SyntaxRange#Include('#+BEGIN_SRC\ vim', '#+END_SRC', 'vim', 'comment')
-  call SyntaxRange#Include('#+BEGIN_SRC\ python', '#+END_SRC', 'python', 'comment')
-  call SyntaxRange#Include('#+BEGIN_SRC\ c', '#+END_SRC', 'c', 'comment')
-  " cpp must be below c, otherwise you get c syntax hl for cpp files
-  call SyntaxRange#Include('#+BEGIN_SRC\ cpp', '#+END_SRC', 'cpp', 'comment')
-  call SyntaxRange#Include('#+BEGIN_SRC\ ruby', '#+END_SRC', 'ruby', 'comment')
-  " call SyntaxRange#Include('#+BEGIN_SRC\ lua', '#+END_SRC', 'lua', 'comment')
-  " call SyntaxRange#Include('#+BEGIN_SRC\ lisp', '#+END_SRC', 'lisp', 'comment')
-
-  " LaTeX
-  call SyntaxRange#Include('\\begin[.*]{.*}', '\\end{.*}', 'tex')
-  call SyntaxRange#Include('\\begin{.*}', '\\end{.*}', 'tex')
-  call SyntaxRange#Include('\\\[', '\\\]', 'tex')
-  call SyntaxRange#Include('\$[^$]', '\$', 'tex')
-endif
-" }}}
+let s:included_src_languages = {}
+for s:lang in s:valid_begin_src_languages
+  if has_key(s:included_src_languages, s:lang)
+    continue
+  endif
+  exe printf('syntax region dotooBlockSrc%s matchgroup=comment start="#+BEGIN_SRC\ %s" end="#+END_SRC" keepend contains=@dotooBlockSrc%s',
+        \ s:lang, s:lang, s:lang
+        \ )
+  let s:included_src_languages[s:lang] = 1
+endfor
 
 let b:current_syntax = 'dotoo'


### PR DESCRIPTION
This adds basic support for `#+BEGIN_SRC` filetype highlights, mentioned in #65 and #115.
It's simplified version of Tpope's markdown fenced languages, without the support for "aliases" (bash=sh).
I also removed the dependency on SyntaxRange plugin since it's not mentioned anywhere in readme/docs, and this PR should over that use case.