### PR TITLE
Fix tag filter autocomplete to properly handle multiple tags on same headline.

### DIFF
--- a/autoload/dotoo/agenda.vim
+++ b/autoload/dotoo/agenda.vim
@@ -285,9 +285,8 @@ function! dotoo#agenda#filter_tags_complete(A,L,P)
   for key in keys(s:agenda_dotoos)
     let dotoo = s:agenda_dotoos[key]
     let headlines = dotoo.filter('1')
-    let htags = map(headlines, 'v:val.tags')
-    let htags = map(htags, "join(split(v:val,':'),'')")
-    call filter(htags, '!empty(v:val)')
+    let htags = dotoo#utils#flatten(map(headlines, 'split(v:val.tags, ":")'))
+    call filter(htags, '!empty(v:val) && v:val =~? "^".a:A')
     call extend(tags, htags)
   endfor
   return uniq(sort(tags))


### PR DESCRIPTION
Today I noticed that headlines that have multiple tags are not properly parsed for tag filter in agenda.

For example, if I have these tasks:

```
* TODO Private task :PRIVATE:
* TODO Office task :OFFICE:PROJECT:
* TODO General office task :OFFICE:
```

When I select `filter by tags` and start to autocomplete, before it would show this:
```
PRIVATE
OFFICEPROJECT
OFFICE
```

With this fix it shows this:
```
PRIVATE
OFFICE
PROJECT
```

Also, before it didn't filter depending on the input (typing `P` and pressing TAB shows all results), now it filters them down only to `PRIVATE` and `PROJECT`.