### PR TITLE
Fix finding headline and use writefile with append flag.

### DIFF
--- a/autoload/dotoo.vim
+++ b/autoload/dotoo.vim
@@ -25,9 +25,7 @@ function! dotoo#move_headline(headline, target)
         let target = g:dotoo#capture#refile
       end
     endif
-    silent exe 'noauto split' target
-    call append('$', a:headline.serialize())
-    silent wq
+    call writefile(a:headline.serialize(), target, 'a')
   endif
 endfunction
 

--- a/autoload/dotoo/agenda.vim
+++ b/autoload/dotoo/agenda.vim
@@ -193,7 +193,7 @@ function! dotoo#agenda#get_headline_by_title(file_title)
       let filekey .= '.dotoo'
     endif
     let bufname = bufname(filekey)
-    let bufname = empty(bufname) ? bufname(filekey . '.{dotoo,org}') : bufname
+    let bufname = empty(bufname) ? bufname(substitute(filekey, '\.dotoo$', '', '') . '.{dotoo,org}') : bufname
     let dotoo = get(s:agenda_dotoos, bufname, '')
     if !empty(dotoo)
       let headlines = dotoo.filter("v:val.title =~# '" . title . "'")


### PR DESCRIPTION
This PR fixes 2 things:

1. Uses `writefile()` with `a` flag when moving headline from one file to another instead of opening target file in the split view. Opening file in split view messes up the focus for me after headline is moved because it focuses the wrong window.
2. Remove `.dotoo` from filename when trying to figure out the bufname, because `.dotoo` is apended before figuring out the bufname. This is probably happening for me because I use `.org` extension, but since there's some basic support for org extension this fixes it.