### PR TITLE
Fix order of arguments for writefile in refile now.

### DIFF
--- a/autoload/dotoo/capture.vim
+++ b/autoload/dotoo/capture.vim
@@ -96,7 +96,7 @@ function! dotoo#capture#refile_now() abort
         let btarget = g:dotoo#capture#refile
       endif
     endif
-    call writefile(target, headline.serialize(), 'a')
+    call writefile(headline.serialize(), target, 'a')
   endif
 endfunction
 


### PR DESCRIPTION
Writefile that you recently added have a wrong order of arguments. This fixes it.